### PR TITLE
Style Fix: adjust colors, html variables & extends instead of mixins

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,9 +1,14 @@
 :root {
 	--blue: #0096ca;
+	--lightBlue: #61dafb;
 	--green: #28d7a6;
+	--lightGreen: #e6fff8;
 	--orange: #cf5300;
+	--lightOrange: #fff7f2;
 	--purple: #554b86;
+	--lightPurple: #eeecf9;
 	--red: #df0656;
+	--lightRed: #fff8fa;
 
 	--black: #222;
 	--darkGrey: #929292;
@@ -14,14 +19,14 @@
 
 html {
 	--base-color-background: white;
-	--base-color-link: #61dafb;
-	--base-color: white;
+	--base-color-link: var(--lightBlue);
+	--base-color: var(--lightBackground);
 	--base-color-button: var(--darkGrey);
 }
 
 html[data-theme="dark"] {
-	--base-color-background: #282c34;
-	--base-color-link: #fe016c;
-	--base-color: #232323;
+	--base-color-background: var(--darkCardsBackground);
+	--base-color-link: var(--red);
+	--base-color: var(--black);
 	--base-color-button: var(--darkCardsBackground);
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,25 +1,29 @@
-// Shadow
-@mixin shadow {
+// Shadows
+%shadow-banners {
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+%shadow-cards {
 	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 // Box container
-@mixin box {
+%banners {
 	overflow: hidden;
 	background-color: var(--base-color-background);
 	border-radius: 15px;
-	@include shadow;
+	@extend %shadow;
 }
 
-// Titles
-@mixin title {
+// Titles with info icon
+%title {
 	display: flex;
 	flex-wrap: nowrap;
 	align-items: center;
 }
 
 // Round buttons layout
-@mixin button {
+%button {
 	width: 32px;
 	height: 32px;
 	border-radius: 31px;
@@ -28,8 +32,8 @@
 }
 
 // Symptoms card
-@mixin symptomsCard {
+%symptomsCard {
 	width: 202px;
 	height: 291px;
-	@include box;
+	@extend %box;
 }


### PR DESCRIPTION
I restored this branch because I was reading the Sass documentation and fin out that what we needed wasn't Mixins but Extends so I fixed that file but kept its name as _mixins.scss.

Here's a list of the extends:
- %shadow-banners
- %shadow-cards (for the cards inside the banners)
- %banners
- %title (for the ones with info icon)
- %button (round buttons)
- %symptomsCard

I also added the light version colors and adjusted the html variables in the _colors.scss file.