### PR TITLE
Style: Fix z-index and width of NavBar component

### DIFF
--- a/src/components/NavBar/NavBar.scss
+++ b/src/components/NavBar/NavBar.scss
@@ -4,7 +4,8 @@
   position: sticky;
   top: 0;
   left: 0;
-  width: 100%;
+  z-index: 9;
+  width: 300px;
   height: 100vh;
   max-width: 235px;
   padding: 16px 16px 16px 32px;


### PR DESCRIPTION
This solve issue #42 
In medium screen sizes, the NavBar expands correctly and stay top in the stack.
![2BC7DB36-BF7F-4DBE-B343-EE9880CB5514](https://user-images.githubusercontent.com/3743350/89723739-cbd5f880-d9bf-11ea-990e-77505d2127b9.png)
